### PR TITLE
✨ Allow .env file to be optional

### DIFF
--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -20,8 +20,11 @@ func main() {
 	}
 
 	// load env vars
-	if err := godotenv.Load(); err != nil {
-		zl.Fatal("unable to load environment vars: %w", zap.Error(err))
+	if _, err := os.Stat("./.env"); err == nil {
+		zl.Info("detected .env file... loading it in")
+		if err := godotenv.Load(); err != nil {
+			zl.Fatal("unable to load environment vars: %w", zap.Error(err))
+		}
 	}
 
 	// load config


### PR DESCRIPTION
This commit allows the loading of the `.env` file to be optional. The purpose is so that the `.env` file can be used when developing locally but pure environment variables are used when deploying.