### PR TITLE
🐛 Fix closure of postgres pool

### DIFF
--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -65,6 +65,7 @@ func main() {
 
 	// close
 	srv.Close()
+	p.Close()
 }
 
 func newLogger() (*zap.Logger, zap.AtomicLevel, error) {

--- a/backend/internal/postgres/postgres.go
+++ b/backend/internal/postgres/postgres.go
@@ -46,5 +46,6 @@ func New(zl *zap.Logger, cfg Config) (*Postgres, error) {
 }
 
 func (p *Postgres) Close() error {
-	return p.Close()
+	p.pool.Close()
+	return nil
 }


### PR DESCRIPTION
This commit fixes a bug where the postgres pool
is not properly closed when the application closed. Not closing the pool, leaves the connections open
causing the database to have many active connections and preventing future connections from being made.