### PR TITLE
✅ Add integration tests

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -9,6 +9,14 @@ run:
 	dagger call ledger --src=$${PWD} --postgres=tcp://localhost:5432 up
 .PHONY: run
 
+integration-local:
+	go test -count=1 ./integration
+.PHONY: integration-local
+
+integration:
+	dagger call integration --src=$${PWD} --ledger=tcp://localhost:8080
+.PHONY: integration
+
 postgres-migrate:
 	dagger call postgres-migrate --src=$${PWD} up
 .PHONY: postgres-migrate

--- a/backend/integration/empty_test.go
+++ b/backend/integration/empty_test.go
@@ -1,0 +1,7 @@
+package integration
+
+import "testing"
+
+func TestEmpty(t *testing.T) {
+	t.Log("empty passing test")
+}


### PR DESCRIPTION
This commit adds the ability to execute integration tests. The purpose of such tests is to test the application when it is "integrated" with the dependencies (i.e. database), to verify that it is working end-to-end. Although not used by the current integration test, the dagger function is made to bind against the ledger service, to allow for actual tests against the server in future commits.