### PR TITLE
✨ Add psql utility

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -34,3 +34,7 @@ openapi-generate:
 	mkdir -p ./internal/api
 	dagger call openapi-generate --src=. export --path=$${PWD}/internal/api
 .PHONY: openapi-generate
+
+psql:
+	dagger call psql --svc=tcp://localhost:5432
+.PHONY: psql


### PR DESCRIPTION
This commit adds a dagger function that executes `psql`, useful for dropping into a shell with the database for local development.