### PR TITLE
🎨 Reorder month url parameter

### DIFF
--- a/backend/api/resources/expense_id.yaml
+++ b/backend/api/resources/expense_id.yaml
@@ -5,8 +5,8 @@ put:
   description: Updates an expense line in the ledger
   operationId: updateExpense
   parameters:
-    - $ref: '../parameters/expenseId.yaml'
     - $ref: '../parameters/month.yaml'
+    - $ref: '../parameters/expenseId.yaml'
   requestBody:
     description: Update an expense line in the ledger
     content:
@@ -32,8 +32,8 @@ delete:
   description: Deletes an expense line from the ledger
   operationId: deleteExpense
   parameters:
-    - $ref: '../parameters/expenseId.yaml'
     - $ref: '../parameters/month.yaml'
+    - $ref: '../parameters/expenseId.yaml'
   responses:
     '200':
       description: Successful operation

--- a/backend/api/resources/income_id.yaml
+++ b/backend/api/resources/income_id.yaml
@@ -5,8 +5,8 @@ put:
   description: Updates a line of income in the ledger
   operationId: updateIncome
   parameters:
-    - $ref: '../parameters/incomeId.yaml'
     - $ref: '../parameters/month.yaml'
+    - $ref: '../parameters/incomeId.yaml'
   requestBody:
     description: Update a line of income in the ledger
     content:
@@ -32,8 +32,8 @@ delete:
   description: Deletes a line of income from the ledger
   operationId: deleteIncome
   parameters:
-    - $ref: '../parameters/incomeId.yaml'
     - $ref: '../parameters/month.yaml'
+    - $ref: '../parameters/incomeId.yaml'
   responses:
     '200':
       description: Successful operation

--- a/backend/internal/api/README.md
+++ b/backend/internal/api/README.md
@@ -12,7 +12,7 @@ To see how to make this your own, look here:
 [README](https://openapi-generator.tech)
 
 - API version: 0.0.1
-- Build date: 2025-02-09T08:33:36.846751846Z[Etc/UTC]
+- Build date: 2025-02-25T07:04:54.250081087Z[Etc/UTC]
 - Generator version: 7.12.0-SNAPSHOT
 
 

--- a/backend/internal/api/api/openapi.yaml
+++ b/backend/internal/api/api/openapi.yaml
@@ -50,19 +50,19 @@ paths:
       parameters:
       - description: The id of the income line
         in: path
-        name: incomeId
-        required: true
-        schema:
-          example: 53240c09-79c3-4601-a625-10b4e0715a8d
-          format: guid
-          type: string
-      - description: The id of the income line
-        in: path
         name: month
         required: true
         schema:
           example: 2024-12-01
           format: date
+          type: string
+      - description: The id of the income line
+        in: path
+        name: incomeId
+        required: true
+        schema:
+          example: 53240c09-79c3-4601-a625-10b4e0715a8d
+          format: guid
           type: string
       responses:
         "200":
@@ -84,19 +84,19 @@ paths:
       parameters:
       - description: The id of the income line
         in: path
-        name: incomeId
-        required: true
-        schema:
-          example: 53240c09-79c3-4601-a625-10b4e0715a8d
-          format: guid
-          type: string
-      - description: The id of the income line
-        in: path
         name: month
         required: true
         schema:
           example: 2024-12-01
           format: date
+          type: string
+      - description: The id of the income line
+        in: path
+        name: incomeId
+        required: true
+        schema:
+          example: 53240c09-79c3-4601-a625-10b4e0715a8d
+          format: guid
           type: string
       requestBody:
         content:
@@ -158,14 +158,6 @@ paths:
       description: Deletes an expense line from the ledger
       operationId: deleteExpense
       parameters:
-      - description: The id of the expense line
-        in: path
-        name: expenseId
-        required: true
-        schema:
-          example: 53240c09-79c3-4601-a625-10b4e0715a8d
-          format: guid
-          type: string
       - description: The id of the income line
         in: path
         name: month
@@ -173,6 +165,14 @@ paths:
         schema:
           example: 2024-12-01
           format: date
+          type: string
+      - description: The id of the expense line
+        in: path
+        name: expenseId
+        required: true
+        schema:
+          example: 53240c09-79c3-4601-a625-10b4e0715a8d
+          format: guid
           type: string
       responses:
         "200":
@@ -192,14 +192,6 @@ paths:
       description: Updates an expense line in the ledger
       operationId: updateExpense
       parameters:
-      - description: The id of the expense line
-        in: path
-        name: expenseId
-        required: true
-        schema:
-          example: 53240c09-79c3-4601-a625-10b4e0715a8d
-          format: guid
-          type: string
       - description: The id of the income line
         in: path
         name: month
@@ -207,6 +199,14 @@ paths:
         schema:
           example: 2024-12-01
           format: date
+          type: string
+      - description: The id of the expense line
+        in: path
+        name: expenseId
+        required: true
+        schema:
+          example: 53240c09-79c3-4601-a625-10b4e0715a8d
+          format: guid
           type: string
       requestBody:
         content:

--- a/backend/internal/api/go/api_ledger.go
+++ b/backend/internal/api/go/api_ledger.go
@@ -120,14 +120,14 @@ func (c *LedgerAPIController) AddIncome(w http.ResponseWriter, r *http.Request) 
 // UpdateIncome - Update a line of income
 func (c *LedgerAPIController) UpdateIncome(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	incomeIdParam := params["incomeId"]
-	if incomeIdParam == "" {
-		c.errorHandler(w, r, &RequiredError{"incomeId"}, nil)
-		return
-	}
 	monthParam := params["month"]
 	if monthParam == "" {
 		c.errorHandler(w, r, &RequiredError{"month"}, nil)
+		return
+	}
+	incomeIdParam := params["incomeId"]
+	if incomeIdParam == "" {
+		c.errorHandler(w, r, &RequiredError{"incomeId"}, nil)
 		return
 	}
 	var incomeParam Income
@@ -145,7 +145,7 @@ func (c *LedgerAPIController) UpdateIncome(w http.ResponseWriter, r *http.Reques
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.UpdateIncome(r.Context(), incomeIdParam, monthParam, incomeParam)
+	result, err := c.service.UpdateIncome(r.Context(), monthParam, incomeIdParam, incomeParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -158,17 +158,17 @@ func (c *LedgerAPIController) UpdateIncome(w http.ResponseWriter, r *http.Reques
 // DeleteIncome - Delete a line of income
 func (c *LedgerAPIController) DeleteIncome(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	incomeIdParam := params["incomeId"]
-	if incomeIdParam == "" {
-		c.errorHandler(w, r, &RequiredError{"incomeId"}, nil)
-		return
-	}
 	monthParam := params["month"]
 	if monthParam == "" {
 		c.errorHandler(w, r, &RequiredError{"month"}, nil)
 		return
 	}
-	result, err := c.service.DeleteIncome(r.Context(), incomeIdParam, monthParam)
+	incomeIdParam := params["incomeId"]
+	if incomeIdParam == "" {
+		c.errorHandler(w, r, &RequiredError{"incomeId"}, nil)
+		return
+	}
+	result, err := c.service.DeleteIncome(r.Context(), monthParam, incomeIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -214,14 +214,14 @@ func (c *LedgerAPIController) AddExpense(w http.ResponseWriter, r *http.Request)
 // UpdateExpense - Update an expense line
 func (c *LedgerAPIController) UpdateExpense(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	expenseIdParam := params["expenseId"]
-	if expenseIdParam == "" {
-		c.errorHandler(w, r, &RequiredError{"expenseId"}, nil)
-		return
-	}
 	monthParam := params["month"]
 	if monthParam == "" {
 		c.errorHandler(w, r, &RequiredError{"month"}, nil)
+		return
+	}
+	expenseIdParam := params["expenseId"]
+	if expenseIdParam == "" {
+		c.errorHandler(w, r, &RequiredError{"expenseId"}, nil)
 		return
 	}
 	var expenseParam Expense
@@ -239,7 +239,7 @@ func (c *LedgerAPIController) UpdateExpense(w http.ResponseWriter, r *http.Reque
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.UpdateExpense(r.Context(), expenseIdParam, monthParam, expenseParam)
+	result, err := c.service.UpdateExpense(r.Context(), monthParam, expenseIdParam, expenseParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -252,17 +252,17 @@ func (c *LedgerAPIController) UpdateExpense(w http.ResponseWriter, r *http.Reque
 // DeleteExpense - Delete an expense line
 func (c *LedgerAPIController) DeleteExpense(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	expenseIdParam := params["expenseId"]
-	if expenseIdParam == "" {
-		c.errorHandler(w, r, &RequiredError{"expenseId"}, nil)
-		return
-	}
 	monthParam := params["month"]
 	if monthParam == "" {
 		c.errorHandler(w, r, &RequiredError{"month"}, nil)
 		return
 	}
-	result, err := c.service.DeleteExpense(r.Context(), expenseIdParam, monthParam)
+	expenseIdParam := params["expenseId"]
+	if expenseIdParam == "" {
+		c.errorHandler(w, r, &RequiredError{"expenseId"}, nil)
+		return
+	}
+	result, err := c.service.DeleteExpense(r.Context(), monthParam, expenseIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/backend/internal/api/go/api_ledger_service.go
+++ b/backend/internal/api/go/api_ledger_service.go
@@ -45,7 +45,7 @@ func (s *LedgerAPIService) AddIncome(ctx context.Context, month string, income I
 }
 
 // UpdateIncome - Update a line of income
-func (s *LedgerAPIService) UpdateIncome(ctx context.Context, incomeId string, month string, income Income) (ImplResponse, error) {
+func (s *LedgerAPIService) UpdateIncome(ctx context.Context, month string, incomeId string, income Income) (ImplResponse, error) {
 	// TODO - update UpdateIncome with the required logic for this service method.
 	// Add api_ledger_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
@@ -62,7 +62,7 @@ func (s *LedgerAPIService) UpdateIncome(ctx context.Context, incomeId string, mo
 }
 
 // DeleteIncome - Delete a line of income
-func (s *LedgerAPIService) DeleteIncome(ctx context.Context, incomeId string, month string) (ImplResponse, error) {
+func (s *LedgerAPIService) DeleteIncome(ctx context.Context, month string, incomeId string) (ImplResponse, error) {
 	// TODO - update DeleteIncome with the required logic for this service method.
 	// Add api_ledger_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
@@ -96,7 +96,7 @@ func (s *LedgerAPIService) AddExpense(ctx context.Context, month string, expense
 }
 
 // UpdateExpense - Update an expense line
-func (s *LedgerAPIService) UpdateExpense(ctx context.Context, expenseId string, month string, expense Expense) (ImplResponse, error) {
+func (s *LedgerAPIService) UpdateExpense(ctx context.Context, month string, expenseId string, expense Expense) (ImplResponse, error) {
 	// TODO - update UpdateExpense with the required logic for this service method.
 	// Add api_ledger_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
@@ -113,7 +113,7 @@ func (s *LedgerAPIService) UpdateExpense(ctx context.Context, expenseId string, 
 }
 
 // DeleteExpense - Delete an expense line
-func (s *LedgerAPIService) DeleteExpense(ctx context.Context, expenseId string, month string) (ImplResponse, error) {
+func (s *LedgerAPIService) DeleteExpense(ctx context.Context, month string, expenseId string) (ImplResponse, error) {
 	// TODO - update DeleteExpense with the required logic for this service method.
 	// Add api_ledger_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 


### PR DESCRIPTION
This commit reorders the month path parameter so that it is first, matching the resource path. This improves the consistency of the spec and allows the order
of parameters in generated code to follow the order of path parameters in the resource path.