### PR TITLE
🎨 Change month type from string to int

### DIFF
--- a/backend/api/parameters/month.yaml
+++ b/backend/api/parameters/month.yaml
@@ -3,6 +3,7 @@ in: path
 description: The id of the income line
 required: true
 schema:
-  type: string
-  format: date
-  example: "2024-12-01"
+  type: integer
+  minimum: 0
+  maximum: 11
+  example: "0"

--- a/backend/internal/api/README.md
+++ b/backend/internal/api/README.md
@@ -12,7 +12,7 @@ To see how to make this your own, look here:
 [README](https://openapi-generator.tech)
 
 - API version: 0.0.1
-- Build date: 2025-02-25T07:04:54.250081087Z[Etc/UTC]
+- Build date: 2025-02-25T07:10:37.273619813Z[Etc/UTC]
 - Generator version: 7.12.0-SNAPSHOT
 
 

--- a/backend/internal/api/api/openapi.yaml
+++ b/backend/internal/api/api/openapi.yaml
@@ -19,9 +19,10 @@ paths:
         name: month
         required: true
         schema:
-          example: 2024-12-01
-          format: date
-          type: string
+          example: 0
+          maximum: 11
+          minimum: 0
+          type: integer
       requestBody:
         content:
           application/json:
@@ -53,9 +54,10 @@ paths:
         name: month
         required: true
         schema:
-          example: 2024-12-01
-          format: date
-          type: string
+          example: 0
+          maximum: 11
+          minimum: 0
+          type: integer
       - description: The id of the income line
         in: path
         name: incomeId
@@ -87,9 +89,10 @@ paths:
         name: month
         required: true
         schema:
-          example: 2024-12-01
-          format: date
-          type: string
+          example: 0
+          maximum: 11
+          minimum: 0
+          type: integer
       - description: The id of the income line
         in: path
         name: incomeId
@@ -129,9 +132,10 @@ paths:
         name: month
         required: true
         schema:
-          example: 2024-12-01
-          format: date
-          type: string
+          example: 0
+          maximum: 11
+          minimum: 0
+          type: integer
       requestBody:
         content:
           application/json:
@@ -163,9 +167,10 @@ paths:
         name: month
         required: true
         schema:
-          example: 2024-12-01
-          format: date
-          type: string
+          example: 0
+          maximum: 11
+          minimum: 0
+          type: integer
       - description: The id of the expense line
         in: path
         name: expenseId
@@ -197,9 +202,10 @@ paths:
         name: month
         required: true
         schema:
-          example: 2024-12-01
-          format: date
-          type: string
+          example: 0
+          maximum: 11
+          minimum: 0
+          type: integer
       - description: The id of the expense line
         in: path
         name: expenseId
@@ -237,9 +243,10 @@ components:
       name: month
       required: true
       schema:
-        example: 2024-12-01
-        format: date
-        type: string
+        example: 0
+        maximum: 11
+        minimum: 0
+        type: integer
     incomeId:
       description: The id of the income line
       in: path

--- a/backend/internal/api/go/api.go
+++ b/backend/internal/api/go/api.go
@@ -35,10 +35,10 @@ type LedgerAPIRouter interface {
 // while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type LedgerAPIServicer interface { 
-	AddIncome(context.Context, string, Income) (ImplResponse, error)
-	UpdateIncome(context.Context, string, string, Income) (ImplResponse, error)
-	DeleteIncome(context.Context, string, string) (ImplResponse, error)
-	AddExpense(context.Context, string, Expense) (ImplResponse, error)
-	UpdateExpense(context.Context, string, string, Expense) (ImplResponse, error)
-	DeleteExpense(context.Context, string, string) (ImplResponse, error)
+	AddIncome(context.Context, int32, Income) (ImplResponse, error)
+	UpdateIncome(context.Context, int32, string, Income) (ImplResponse, error)
+	DeleteIncome(context.Context, int32, string) (ImplResponse, error)
+	AddExpense(context.Context, int32, Expense) (ImplResponse, error)
+	UpdateExpense(context.Context, int32, string, Expense) (ImplResponse, error)
+	DeleteExpense(context.Context, int32, string) (ImplResponse, error)
 }

--- a/backend/internal/api/go/api_ledger.go
+++ b/backend/internal/api/go/api_ledger.go
@@ -87,9 +87,14 @@ func (c *LedgerAPIController) Routes() Routes {
 // AddIncome - Add a new line of income
 func (c *LedgerAPIController) AddIncome(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	monthParam := params["month"]
-	if monthParam == "" {
-		c.errorHandler(w, r, &RequiredError{"month"}, nil)
+	monthParam, err := parseNumericParameter[int32](
+		params["month"],
+		WithRequire[int32](parseInt32),
+		WithMinimum[int32](0),
+		WithMaximum[int32](11),
+	)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "month", Err: err}, nil)
 		return
 	}
 	var incomeParam Income
@@ -120,9 +125,14 @@ func (c *LedgerAPIController) AddIncome(w http.ResponseWriter, r *http.Request) 
 // UpdateIncome - Update a line of income
 func (c *LedgerAPIController) UpdateIncome(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	monthParam := params["month"]
-	if monthParam == "" {
-		c.errorHandler(w, r, &RequiredError{"month"}, nil)
+	monthParam, err := parseNumericParameter[int32](
+		params["month"],
+		WithRequire[int32](parseInt32),
+		WithMinimum[int32](0),
+		WithMaximum[int32](11),
+	)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "month", Err: err}, nil)
 		return
 	}
 	incomeIdParam := params["incomeId"]
@@ -158,9 +168,14 @@ func (c *LedgerAPIController) UpdateIncome(w http.ResponseWriter, r *http.Reques
 // DeleteIncome - Delete a line of income
 func (c *LedgerAPIController) DeleteIncome(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	monthParam := params["month"]
-	if monthParam == "" {
-		c.errorHandler(w, r, &RequiredError{"month"}, nil)
+	monthParam, err := parseNumericParameter[int32](
+		params["month"],
+		WithRequire[int32](parseInt32),
+		WithMinimum[int32](0),
+		WithMaximum[int32](11),
+	)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "month", Err: err}, nil)
 		return
 	}
 	incomeIdParam := params["incomeId"]
@@ -181,9 +196,14 @@ func (c *LedgerAPIController) DeleteIncome(w http.ResponseWriter, r *http.Reques
 // AddExpense - Add a new expense line
 func (c *LedgerAPIController) AddExpense(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	monthParam := params["month"]
-	if monthParam == "" {
-		c.errorHandler(w, r, &RequiredError{"month"}, nil)
+	monthParam, err := parseNumericParameter[int32](
+		params["month"],
+		WithRequire[int32](parseInt32),
+		WithMinimum[int32](0),
+		WithMaximum[int32](11),
+	)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "month", Err: err}, nil)
 		return
 	}
 	var expenseParam Expense
@@ -214,9 +234,14 @@ func (c *LedgerAPIController) AddExpense(w http.ResponseWriter, r *http.Request)
 // UpdateExpense - Update an expense line
 func (c *LedgerAPIController) UpdateExpense(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	monthParam := params["month"]
-	if monthParam == "" {
-		c.errorHandler(w, r, &RequiredError{"month"}, nil)
+	monthParam, err := parseNumericParameter[int32](
+		params["month"],
+		WithRequire[int32](parseInt32),
+		WithMinimum[int32](0),
+		WithMaximum[int32](11),
+	)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "month", Err: err}, nil)
 		return
 	}
 	expenseIdParam := params["expenseId"]
@@ -252,9 +277,14 @@ func (c *LedgerAPIController) UpdateExpense(w http.ResponseWriter, r *http.Reque
 // DeleteExpense - Delete an expense line
 func (c *LedgerAPIController) DeleteExpense(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	monthParam := params["month"]
-	if monthParam == "" {
-		c.errorHandler(w, r, &RequiredError{"month"}, nil)
+	monthParam, err := parseNumericParameter[int32](
+		params["month"],
+		WithRequire[int32](parseInt32),
+		WithMinimum[int32](0),
+		WithMaximum[int32](11),
+	)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "month", Err: err}, nil)
 		return
 	}
 	expenseIdParam := params["expenseId"]

--- a/backend/internal/api/go/api_ledger_service.go
+++ b/backend/internal/api/go/api_ledger_service.go
@@ -28,7 +28,7 @@ func NewLedgerAPIService() *LedgerAPIService {
 }
 
 // AddIncome - Add a new line of income
-func (s *LedgerAPIService) AddIncome(ctx context.Context, month string, income Income) (ImplResponse, error) {
+func (s *LedgerAPIService) AddIncome(ctx context.Context, month int32, income Income) (ImplResponse, error) {
 	// TODO - update AddIncome with the required logic for this service method.
 	// Add api_ledger_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
@@ -45,7 +45,7 @@ func (s *LedgerAPIService) AddIncome(ctx context.Context, month string, income I
 }
 
 // UpdateIncome - Update a line of income
-func (s *LedgerAPIService) UpdateIncome(ctx context.Context, month string, incomeId string, income Income) (ImplResponse, error) {
+func (s *LedgerAPIService) UpdateIncome(ctx context.Context, month int32, incomeId string, income Income) (ImplResponse, error) {
 	// TODO - update UpdateIncome with the required logic for this service method.
 	// Add api_ledger_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
@@ -62,7 +62,7 @@ func (s *LedgerAPIService) UpdateIncome(ctx context.Context, month string, incom
 }
 
 // DeleteIncome - Delete a line of income
-func (s *LedgerAPIService) DeleteIncome(ctx context.Context, month string, incomeId string) (ImplResponse, error) {
+func (s *LedgerAPIService) DeleteIncome(ctx context.Context, month int32, incomeId string) (ImplResponse, error) {
 	// TODO - update DeleteIncome with the required logic for this service method.
 	// Add api_ledger_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
@@ -79,7 +79,7 @@ func (s *LedgerAPIService) DeleteIncome(ctx context.Context, month string, incom
 }
 
 // AddExpense - Add a new expense line
-func (s *LedgerAPIService) AddExpense(ctx context.Context, month string, expense Expense) (ImplResponse, error) {
+func (s *LedgerAPIService) AddExpense(ctx context.Context, month int32, expense Expense) (ImplResponse, error) {
 	// TODO - update AddExpense with the required logic for this service method.
 	// Add api_ledger_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
@@ -96,7 +96,7 @@ func (s *LedgerAPIService) AddExpense(ctx context.Context, month string, expense
 }
 
 // UpdateExpense - Update an expense line
-func (s *LedgerAPIService) UpdateExpense(ctx context.Context, month string, expenseId string, expense Expense) (ImplResponse, error) {
+func (s *LedgerAPIService) UpdateExpense(ctx context.Context, month int32, expenseId string, expense Expense) (ImplResponse, error) {
 	// TODO - update UpdateExpense with the required logic for this service method.
 	// Add api_ledger_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
@@ -113,7 +113,7 @@ func (s *LedgerAPIService) UpdateExpense(ctx context.Context, month string, expe
 }
 
 // DeleteExpense - Delete an expense line
-func (s *LedgerAPIService) DeleteExpense(ctx context.Context, month string, expenseId string) (ImplResponse, error) {
+func (s *LedgerAPIService) DeleteExpense(ctx context.Context, month int32, expenseId string) (ImplResponse, error) {
 	// TODO - update DeleteExpense with the required logic for this service method.
 	// Add api_ledger_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 

--- a/backend/internal/server/expense.go
+++ b/backend/internal/server/expense.go
@@ -7,12 +7,12 @@ import (
 	openapi "github.com/chrisjpalmer/ledger/backend/internal/api/go"
 )
 
-func (s *Server) AddExpense(ctx context.Context, month string, expense openapi.Expense) (openapi.ImplResponse, error) {
+func (s *Server) AddExpense(ctx context.Context, month int32, expense openapi.Expense) (openapi.ImplResponse, error) {
 	return openapi.Response(http.StatusNotImplemented, nil), nil
 }
-func (s *Server) UpdateExpense(ctx context.Context, month string, expenseID string, expense openapi.Expense) (openapi.ImplResponse, error) {
+func (s *Server) UpdateExpense(ctx context.Context, month int32, expenseID string, expense openapi.Expense) (openapi.ImplResponse, error) {
 	return openapi.Response(http.StatusNotImplemented, nil), nil
 }
-func (s *Server) DeleteExpense(ctx context.Context, month string, expenseID string) (openapi.ImplResponse, error) {
+func (s *Server) DeleteExpense(ctx context.Context, month int32, expenseID string) (openapi.ImplResponse, error) {
 	return openapi.Response(http.StatusNotImplemented, nil), nil
 }

--- a/backend/internal/server/income.go
+++ b/backend/internal/server/income.go
@@ -7,14 +7,14 @@ import (
 	openapi "github.com/chrisjpalmer/ledger/backend/internal/api/go"
 )
 
-func (s *Server) AddIncome(ctx context.Context, month string, income openapi.Income) (openapi.ImplResponse, error) {
+func (s *Server) AddIncome(ctx context.Context, month int32, income openapi.Income) (openapi.ImplResponse, error) {
 	return openapi.Response(http.StatusNotImplemented, nil), nil
 }
 
-func (s *Server) UpdateIncome(ctx context.Context, month string, incomeID string, income openapi.Income) (openapi.ImplResponse, error) {
+func (s *Server) UpdateIncome(ctx context.Context, month int32, incomeID string, income openapi.Income) (openapi.ImplResponse, error) {
 	return openapi.Response(http.StatusNotImplemented, nil), nil
 }
 
-func (s *Server) DeleteIncome(ctx context.Context, month string, incomeID string) (openapi.ImplResponse, error) {
+func (s *Server) DeleteIncome(ctx context.Context, month int32, incomeID string) (openapi.ImplResponse, error) {
 	return openapi.Response(http.StatusNotImplemented, nil), nil
 }


### PR DESCRIPTION
This commit changes the month type in the API spec from a string to an int. Originally the month was intended to hold a date-time formatted string, however this is excessive for what is required and a simple integer expressing the month is enough