### PR TITLE
🐛 Fix expenses resource path

### DIFF
--- a/backend/api/spec.yaml
+++ b/backend/api/spec.yaml
@@ -14,7 +14,7 @@ paths:
     $ref: './resources/income_id.yaml'
   /month/{month}/expense:
     $ref: './resources/expense.yaml'
-  /month/{month}/expense_id:
+  /month/{month}/expense/{expenseId}:
     $ref: './resources/expense_id.yaml'
 components:
   schemas:

--- a/backend/internal/api/README.md
+++ b/backend/internal/api/README.md
@@ -12,7 +12,7 @@ To see how to make this your own, look here:
 [README](https://openapi-generator.tech)
 
 - API version: 0.0.1
-- Build date: 2025-02-25T07:10:37.273619813Z[Etc/UTC]
+- Build date: 2025-02-25T07:16:00.697487898Z[Etc/UTC]
 - Generator version: 7.12.0-SNAPSHOT
 
 

--- a/backend/internal/api/api/openapi.yaml
+++ b/backend/internal/api/api/openapi.yaml
@@ -157,7 +157,7 @@ paths:
       summary: Add a new expense line
       tags:
       - ledger
-  /month/{month}/expense_id:
+  /month/{month}/expense/{expenseId}:
     delete:
       description: Deletes an expense line from the ledger
       operationId: deleteExpense

--- a/backend/internal/api/go/api_ledger.go
+++ b/backend/internal/api/go/api_ledger.go
@@ -73,12 +73,12 @@ func (c *LedgerAPIController) Routes() Routes {
 		},
 		"UpdateExpense": Route{
 			strings.ToUpper("Put"),
-			"/month/{month}/expense_id",
+			"/month/{month}/expense/{expenseId}",
 			c.UpdateExpense,
 		},
 		"DeleteExpense": Route{
 			strings.ToUpper("Delete"),
-			"/month/{month}/expense_id",
+			"/month/{month}/expense/{expenseId}",
 			c.DeleteExpense,
 		},
 	}


### PR DESCRIPTION
This commit fixes the resource expenses by ensuring this resource path includes the `expense_id` path
parameter. This will be important for allowing
read, update and delete operations.