### PR TITLE
🔥 Avoid mounting output dir to api generate

### DIFF
--- a/backend/.dagger/dependencies.go
+++ b/backend/.dagger/dependencies.go
@@ -69,7 +69,6 @@ func (m *Backend) OpenapiGenerate(ctx context.Context, src *dagger.Directory) *d
 	return dag.Container().
 		From("openapitools/openapi-generator-cli").
 		WithDirectory("/local", src.Directory("api")).
-		WithDirectory("/out", src.Directory("internal/api")).
 		WithExec([]string{
 			"generate",
 			"-i", "/local/spec.yaml",


### PR DESCRIPTION
This commit removes a line of code which unecessarily mounts the output director to the openapi generate command. Although the effect is the same as keeping it there, this change is being done more for correctness sake and to minimise unexpected behaviour.