### PR TITLE
✨ detect drift in api generated code

### DIFF
--- a/backend/.dagger/main.go
+++ b/backend/.dagger/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"dagger/backend/internal/dagger"
+	"strings"
 )
 
 const AlpineVersion = "alpine:3.20"
@@ -26,8 +27,19 @@ func (m *Backend) CheckPullRequest(ctx context.Context, src *dagger.Directory) (
 	}
 	defer ledger.Stop(ctx)
 
+	// run open api drift
+	drift, err := m.OpenapiDrift(ctx, src)
+	if err != nil {
+		return "", err
+	}
+
 	// run integration
-	return m.Integration(ctx, src, ledger)
+	integ, err := m.Integration(ctx, src, ledger)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.Join([]string{drift, integ}, "\n\n"), nil
 }
 
 // Ledger - runs the ledger application

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -29,6 +29,10 @@ migrate:
 	dagger call migrate --src=$${PWD} --svc=tcp://localhost:5432
 .PHONY: migrate
 
+openapi-drift:
+	dagger call openapi-drift --src=.
+.PHONY: openapi-drift
+
 openapi-generate:
 	rm -rf ./internal/api
 	mkdir -p ./internal/api


### PR DESCRIPTION
This commit introduces an additional check to the
check-pull-request job, which runs api spec
generation and compares it to what is currently in the repo. The intention is to detect whether the generated code is in anyway different to what is in the repo, in which case the check-pull-request job should fail. This will enforce that developers dont forget
to rerun api generation after changing the spec.