### PR TITLE
♻️ Refactor load dotenv to config pkg

### DIFF
--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/chrisjpalmer/ledger/backend/config"
 	"github.com/chrisjpalmer/ledger/backend/internal/postgres"
 	"github.com/chrisjpalmer/ledger/backend/internal/server"
-	"github.com/joho/godotenv"
 	"go.uber.org/zap"
 )
 
@@ -20,9 +19,9 @@ func main() {
 	}
 
 	// load env vars
-	if _, err := os.Stat("./.env"); err == nil {
+	if config.HasDotEnv(".") {
 		zl.Info("detected .env file... loading it in")
-		if err := godotenv.Load(); err != nil {
+		if err := config.LoadDotEnv("."); err != nil {
 			zl.Fatal("unable to load environment vars: %w", zap.Error(err))
 		}
 	}

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -3,12 +3,26 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/chrisjpalmer/ledger/backend/internal/postgres"
 	"github.com/chrisjpalmer/ledger/backend/internal/server"
+	"github.com/joho/godotenv"
 	"go.uber.org/zap/zapcore"
 )
+
+// HasDotEnv - returns true if a .env file exists
+func HasDotEnv(dir string) bool {
+	stat, err := os.Stat(filepath.Join(dir, ".env"))
+	_ = stat
+	return err == nil
+}
+
+// LoadDotEnv - attempts to load the .env file
+func LoadDotEnv(dir string) error {
+	return godotenv.Load(filepath.Join(dir, ".env"))
+}
 
 type Config struct {
 	LogLevel zapcore.Level


### PR DESCRIPTION
Refactors the functionality that loads the dotenv
back to the `config` package for better isolation
and reusablility. Other packages (such as test)
packages may benefit from using this functionality in the future.